### PR TITLE
Filter out duplicate examples

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,10 @@ const useExamples = (regexp: RegExp | undefined): string[] => {
     return Array(NUMBER_OF_EXAMPLES)
       .fill("")
       .map(() => new Randexp(regexp).gen())
-      .filter(Boolean);
+      .filter(Boolean)
+      .filter(
+        (example, index, exampleList) => exampleList.indexOf(example) === index
+      );
   }, [regexp]);
 };
 


### PR DESCRIPTION
Only show unique examples in the list. So it can vary between 1 to 5 examples.
Better than showing the same example 5 times repeated for certain conditions.